### PR TITLE
CONTRIBUTING: Make leader-issues optional

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,10 @@ Fork the repo and make changes on your fork in a feature branch:
 - If it's a feature branch, create an enhancement issue to announce your
   intentions, and name it XXX-something where XXX is the number of the issue.
 
+Small changes or changes that have been discussed on the project mailing list
+may be submitted without a leader issue, in which case you are free to name
+your branch however you like.
+
 Submit unit tests for your changes.  Go has a great test framework built in; use
 it! Take a look at existing tests for inspiration. Run the full test suite on
 your branch before submitting a pull request.


### PR DESCRIPTION
For small projects like ocitools a strict requirement would just be
busywork.  And the risk here (a submitted PR that would have been
rejected or redirected in a leader issue) is a risk assumed by the
submitter (who sunk time in the wrong direction) and not much cost to
the maintainers.

Addresses [my ocitools comment][1].

[1]: https://github.com/opencontainers/ocitools/pull/56#discussion_r61934206