### PR TITLE
CONTRIBUTING: Make the test requirements contingent on an existing suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,9 +28,9 @@ Small changes or changes that have been discussed on the project mailing list
 may be submitted without a leader issue, in which case you are free to name
 your branch however you like.
 
-Submit unit tests for your changes.  Go has a great test framework built in; use
-it! Take a look at existing tests for inspiration. Run the full test suite on
-your branch before submitting a pull request.
+If the project has a test suite, submit unit tests for your changes. Take a
+look at existing tests for inspiration. Run the full test suite on your branch
+before submitting a pull request.
 
 Update the documentation when creating or modifying features. Test
 your documentation changes for clarity, concision, and correctness, as
@@ -58,8 +58,9 @@ comment.
 
 Before the pull request is merged, make sure that you squash your commits into
 logical units of work using `git rebase -i` and `git push -f`. After every
-commit the test suite should be passing. Include documentation changes in the
-same commit so that a revert would remove all traces of the feature or fix.
+commit the test suite (if any) should be passing. Include documentation changes
+in the same commit so that a revert would remove all traces of the feature or
+fix.
 
 Commits that fix or close an issue should include a reference like `Closes #XXX`
 or `Fixes #XXX`, which will automatically close the issue when merged.


### PR DESCRIPTION
Small, young projects like ocitools may not have grown a test suite
yet.  Don't make writing a Go test suite a requirement for submitting
a PR.

Also allow for other test frameworks, since Go's framework may not be
the best fit for all projects, which may not even include Go code.

Addresses [my ocitools comment][1].

[1]: https://github.com/opencontainers/ocitools/pull/56#discussion_r61934477