### PR TITLE
CONTRIBUTING: Allow collaborative pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,6 @@ committing your changes. Most editors have plugins that do this automatically.
 Pull requests descriptions should be as clear as possible and include a
 reference to all the issues that they address.
 
-Pull requests must not contain commits from other users or branches.
-
 Commit messages must start with a capitalized and short summary
 written in the imperative, followed by an optional, more detailed
 explanatory text which is separated from the summary by an empty line.


### PR DESCRIPTION
For runtime-spec, there are often PRs that pickup and reroll another
user's commits (e.g. opencontainers/runtime-spec#337). As long as the
Signed-off-by entries are there (for the DCO) and the new PR
references the earlier work (to avoid maintainer confusion), I see no
problem with this sort of collaboration.

I thought about replacing the old wording with words like the above
paragraph, but it seemed overly prescriptive.