### PR TITLE
CONTRIBUTING: Don't tell people to make clear pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,9 +37,6 @@ Write clean code. Universally formatted code promotes ease of writing, reading,
 and maintenance. Always run `gofmt -s -w file.go` on each changed file before
 committing your changes. Most editors have plugins that do this automatically.
 
-Pull requests descriptions should be as clear as possible and include a
-reference to all the issues that they address.
-
 Pull requests must not contain commits from other users or branches.
 
 Commit messages must start with a capitalized and short summary (max. 50


### PR DESCRIPTION
I think this sort of generic hygiene advice lowers the signal/noise
for this file, since I'm more interested in what this project wants
that other projects may not want, and everybody wants well-described
PRs.  And I suspect that folks who are inclined to post
poorly-described PRs are less likely to be reading CONTRIBUTING in
detail anyway ;).

Addresses [my ocitools comment][1].

[1]: https://github.com/opencontainers/ocitools/pull/56#discussion_r61935601