### PR TITLE
CONTRIBUTING: Don't specify a 50-char limit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,8 @@ reference to all the issues that they address.
 
 Pull requests must not contain commits from other users or branches.
 
-Commit messages must start with a capitalized and short summary (max. 50
-chars) written in the imperative, followed by an optional, more detailed
+Commit messages must start with a capitalized and short summary
+written in the imperative, followed by an optional, more detailed
 explanatory text which is separated from the summary by an empty line.
 
 Code review comments may be added to your pull request. Discuss, then make the


### PR DESCRIPTION
Folks have been dragging this around from the soft limit in
git-commit(1) and git.git's Documentation/SubmittingPatches without
believing it.  Looking at the git.git history through v2.3.4 (git log
--no-merges --format=%s v2.3.4), we have 29853 commits, with 56% ≤ 50
chars and 94% ≤ 70 chars.  Projects that want limits should enforce
them with CI tests (e.g. runtime-spec uses git-validation, which has
[a soft limit at 72 and a hard limit at 90][1]).

See also discussion [here][2].

[1]: https://github.com/vbatts/git-validation/blob/be3aee994370184fd98e455abfe0948d6f45f793/rules/shortsubject/shortsubject.go#L24-L35
[2]: https://github.com/opencontainers/runtime-spec/pull/168#discussion_r39108346