### PR TITLE
MAINTAINERS: disallow self-LGTMs

### DIFF
--- a/MAINTAINERS_GUIDE.md
+++ b/MAINTAINERS_GUIDE.md
@@ -64,7 +64,9 @@ All decisions are pull requests, and the relevant maintainers make
 decisions by accepting or refusing the pull request. Review and acceptance
 by anyone is denoted by adding a comment in the pull request: `LGTM`.
 However, only currently listed `MAINTAINERS` are counted towards the required
-two LGTMs.
+two LGTMs. In addition, if a maintainer has created a pull request, they cannot
+count toward the two LGTM rule (to ensure equal amounts of review for every pull
+request, no matter who wrote it).
 
 Overall the maintainer system works because of mutual respect across the
 maintainers of the project.  The maintainers trust one another to make decisions


### PR DESCRIPTION
Apart from being a sign of respect to other maintainers, it also ensures
that *all* pull requests get equal amounts of review -- no matter who
wrote them. Maintainers should know better than to make broken
patchsets, but it's also a sign of respect to the community that all
pull requests have equal treatment.

Signed-off-by: Aleksa Sarai <asarai@suse.de>