### PR TITLE
.pullapprove.yml: Ignore author approval (no self-LGTMs)

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -2,6 +2,7 @@ approve_by_comment: true
 approve_regex: ^LGTM
 reject_regex: ^Rejected
 reset_on_push: false
+author_approval: ignored
 reviewers:
   teams:
   - tdc-maintainers


### PR DESCRIPTION
I'm personally fine with [leaving this sort of policing up to the maintainers][1].  But explicit no-self-LGTM docs landed in #13, and it's good to be internally consistent.

[1]: https://github.com/opencontainers/project-template/pull/13#issuecomment-222063443