### PR TITLE
GOVERNANCE: Proposing a motion is a LGTM by default

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -15,6 +15,7 @@ A maintainer SHOULD propose a motion on the dev@opencontainers.org mailing list 
 Voting on a proposed motion SHOULD happen on the dev@opencontainers.org mailing list (except [security issues](#security-issues)) with maintainers posting LGTM or REJECT.
 Maintainers MAY also explicitly not vote by posting ABSTAIN (which is useful to revert a previous vote).
 Maintainers MAY post multiple times (e.g. as they revise their position based on feeback), but only their final post counts in the tally.
+Unless the sponsor(s) explicitly REJECT or ABSTAIN the proposal, the submitting the proposal counts as a LGTM.
 A proposed motion is adopted if two-thirds of votes cast, a quorum having voted, are in favor of the release.
 
 Voting SHOULD remain open for a week to collect feedback from the wider community and allow the maintainers to digest the proposed motion.


### PR DESCRIPTION
To avoid uncertainty like [this](https://groups.google.com/a/opencontainers.org/d/msg/dev/5qj2hATVxew/-ljDGQB0AQAJ).

This is more than a typo-fix, so it probably deserves an
all-maintainers vote to confirm the change.  I'm going to remove the
co-sponsor requirement in a separate PR, and we can batch those two
together for a single vote if that would make life easier for
maintainers.
