### PR TITLE
GOVERNANCE: Drop the co-sponsor requirement

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -8,7 +8,7 @@ This section describes generic rules and procedures for fulfilling that mandate.
 
 ## Proposing a motion
 
-A maintainer SHOULD propose a motion on the dev@opencontainers.org mailing list (except [security issues](#security-issues)) with another maintainer as a co-sponsor.
+A maintainer SHOULD propose a motion on the dev@opencontainers.org mailing list (except [security issues](#security-issues)).
 
 ## Voting
 


### PR DESCRIPTION
In OCI votes to date ([1](https://groups.google.com/a/opencontainers.org/d/msg/tob/WXk1uTgfXrs/-xICOdi1BwAJ), [2](https://groups.google.com/a/opencontainers.org/d/msg/tob/h2x5aLVX2PY/qpry5QXABAAJ), [3](https://groups.google.com/a/opencontainers.org/d/msg/tob/KGyPpu8YfNk/JnOvOEdSBQAJ), [4](https://groups.google.com/a/opencontainers.org/d/msg/dev/XXxKY7w4YA4/KLgQX6iSAQAJ), [5](https://groups.google.com/a/opencontainers.org/d/msg/dev/ik3MIDWq4Us/AqS5GUfuAwAJ), [6](https://groups.google.com/a/opencontainers.org/d/msg/dev/a90Nx4Md6R4/KG2WiSr3AwAJ), [7](https://groups.google.com/a/opencontainers.org/d/msg/dev/FoYcImNQg4c/Re0guPPHBQAJ), [8](https://groups.google.com/a/opencontainers.org/d/msg/tob/ftfzwhD6DpA/QFCi3siaDQAJ), [9](https://groups.google.com/a/opencontainers.org/d/msg/dev/XwIb5czltSE/GKs-6FkGCgAJ), [10](https://groups.google.com/a/opencontainers.org/d/msg/dev/fiDgBKTR9f4/a6B3C-F6DAAJ), [11](https://groups.google.com/a/opencontainers.org/d/msg/dev/5qj2hATVxew/T9xFOcO-EAAJ)), I have only seen a co-sponsor in [9](https://groups.google.com/a/opencontainers.org/d/msg/dev/XwIb5czltSE/GKs-6FkGCgAJ).

I haven't been able to turn up local motivation for this requirement, and don't expect rogue maintainers to flood the list with spam motions now that the co-sponsor requirement has been lifted ;).
