### PR TITLE
.pullapprove.yml: Reset on push, ignore authors, and require sign-offs

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,7 +1,10 @@
 approve_by_comment: true
 approve_regex: ^LGTM
 reject_regex: ^Rejected
-reset_on_push: false
+reset_on_push: true
+author_approval: ignored
+signed_off_by:
+  required: true
 reviewers:
   teams:
   - tdc-maintainers


### PR DESCRIPTION
The sign-off requirement catches us up with fcc7f421 (Add contributing and maintainer guidelines, 2016-05-03, #1).  The author ignore catches us up with c82a2e7 (MAINTAINERS: disallow self-LGTMs, 2016-05-27, #13).

The push reset catches us up with opencontainers/runtime-spec@aa9f3a26 (Add PullApprove checks, 2016-05-26, opencontainers/runtime-spec#458), opencontainers/image-spec@95a46754d (Add PullApprove support to enforce review, 2016-06-01, opencontainers/image-spec#101) and opencontainers/runC@e2fd7c11 (Add PullApprove support, 2016-05-26, opencontainers/runC#847).