### PR TITLE
*: clarify how security issues are handled

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,12 @@
 ## Contribution Guidelines
 
+### Security issues
+
+If you are reporting a security issue, do not create an issue or file a pull
+request on GitHub. Instead, disclose the issue responsibly by sending an email
+to security@opencontainers.org (which is inhabited only by the maintainers of
+the various OCI projects).
+
 ### Pull requests are always welcome
 
 We are always thrilled to receive pull requests, and do our best to

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -31,13 +31,6 @@ A quorum is established when at least two-thirds of maintainers have voted.
 
 For projects that are not specifications, a [motion to release](#release-approval) MAY be adopted if the tally is at least three LGTMs and no REJECTs, even if three votes does not meet the usual two-thirds quorum.
 
-## Security issues
-
-Motions with sensitive security implications MUST be proposed on the security@opencontainers.org mailing list instead of dev@opencontainers.org, but should otherwise follow the standard [proposal](#proposing-a-motion) process.
-The security@opencontainers.org mailing list includes all members of the TOB.
-The TOB will contact the project maintainers and provide a channel for discussing and voting on the motion, but voting will otherwise follow the standard [voting](#voting) and [quorum](#quorum) rules.
-The TOB and project maintainers will work together to notify affected parties before making an adopted motion public.
-
 ## Amendments
 
 The [project governance](#project-governance) rules and procedures MAY be amended or replaced using the procedures themselves.


### PR DESCRIPTION
This PR is in response to the discussions on the ML about the new
security mailing list and how these documents don't match what
the security@opencontainers.org mailing list should be for.

The security@opencontainers.org mailing list is for *maintainers only*,
and is to be used for technical discussion about potential security
issues. It is not a place for the TOB to have votes about
specification-related business, simply because it is not sane to include
people who are not maintainers of projects in critical security
discussions of said projects.

If in the future we discover that we need to have a place to vote on
security issues, the TOB can do that on their own private mailing list.
For now, we should focus on making sure that security disclosures on
*actual shipping code* is actually done properly.

Signed-off-by: Aleksa Sarai <asarai@suse.de>