### PR TITLE
GOVERNANCE: Fix "motion to release" link target (to RELEASES.md)

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -29,7 +29,7 @@ However, a motion MAY be adopted with REJECTs, as outlined in the previous parag
 
 A quorum is established when at least two-thirds of maintainers have voted.
 
-For projects that are not specifications, a [motion to release](#release-approval) MAY be adopted if the tally is at least three LGTMs and no REJECTs, even if three votes does not meet the usual two-thirds quorum.
+For projects that are not specifications, a [motion to release](RELEASES.md) MAY be adopted if the tally is at least three LGTMs and no REJECTs, even if three votes does not meet the usual two-thirds quorum.
 
 ## Security issues
 


### PR DESCRIPTION
I'd garbled the old '#release-approval' target in c732cc2e (#15).

I expect this is a small enough change that it doesn't need the full [amendment procedure][1], but it can certainly go out to an all-OCI-maintainer vote if folks would rather do it that way ;).

[1]: https://github.com/opencontainers/project-template/blob/3eec2a6382c7264073542b4a95024678ee41f0bc/GOVERNANCE.md#amendments