### PR TITLE
GOVERNANCE: Update project list to include *-tools

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -34,7 +34,7 @@ For projects that are not specifications, a [motion to release](#release-approva
 ## Amendments
 
 The [project governance](#project-governance) rules and procedures MAY be amended or replaced using the procedures themselves.
-The MAINTAINERS of this project governance document is the total set of MAINTAINERS from all Open Containers projects (image-spec, image-tools, runC, runtime-spec, and runtime-tools).
+The MAINTAINERS of this project governance document is the total set of MAINTAINERS from all Open Containers projects (go-digest, image-spec, image-tools, runC, runtime-spec, and runtime-tools).
 
 ## Subject templates
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -34,7 +34,7 @@ For projects that are not specifications, a [motion to release](#release-approva
 ## Amendments
 
 The [project governance](#project-governance) rules and procedures MAY be amended or replaced using the procedures themselves.
-The MAINTAINERS of this project governance document is the total set of MAINTAINERS from all Open Containers projects (runC, runtime-spec, and image-spec).
+The MAINTAINERS of this project governance document is the total set of MAINTAINERS from all Open Containers projects (image-spec, image-tools, runC, runtime-spec, and runtime-tools).
 
 ## Subject templates
 


### PR DESCRIPTION
Catching up with opencontainers/tob#18.  I'd rather drop the parenthetical entirely and link to a place that listed OCI Projects, but we don't have a canonical target for that yet (opencontainers/tob#2) and the current closest instance seems to be the GitHub section [here][1] (which doesn't have the "OCI Project"
words).

[1]: https://www.opencontainers.org/community