### PR TITLE
CONTRIBUTING: Remove branch-naming suggestions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,16 +24,9 @@ incorporating a new feature.
 
 ### Conventions
 
-Fork the repo and make changes on your fork in a feature branch:
-
-- If it's a bugfix branch, name it XXX-something where XXX is the number of the
-  issue
-- If it's a feature branch, create an enhancement issue to announce your
-  intentions, and name it XXX-something where XXX is the number of the issue.
-
-Small changes or changes that have been discussed on the project mailing list
-may be submitted without a leader issue, in which case you are free to name
-your branch however you like.
+Fork the repo and make changes on your fork in a feature branch.
+For larger bugs and enhancements, consider filing a leader issue or mailing-list thread for discussion that is independent of the implementation.
+Small changes or changes that have been discussed on the project mailing list may be submitted without a leader issue.
 
 If the project has a test suite, submit unit tests for your changes. Take a
 look at existing tests for inspiration. Run the full test suite on your branch


### PR DESCRIPTION
Extending the earlier softening in #6, because nobody cares about the `XXX-` prefix.  Checking the recent history of all OCI project repos:

    $ for REPO in image-spec image-tools runc runtime-spec runtime-tools;
    > do
    >   (
    >     cd "${REPO} &&
    >     git fetch origin &&
    >     BRANCHES=$(git log --first-parent --oneline origin/master | sed 's/^.* from //') &&
    >     echo "${REPO} branches: $(echo "${BRANCHES}" | wc -l)" &&
    >     echo "${REPO} numbered: $(echo "${BRANCHES}" | grep '/[0-9]' | wc -l)"
    >   );
    > done
    image-spec branches: 276
    image-spec numbered: 1
    image-tools branches: 27
    image-tools numbered: 0
    runc branches: 1299
    runc numbered: 21
    runtime-spec branches: 391
    runtime-spec numbered: 4
    runtime-tools branches: 232
    runtime-tools numbered: 3

Fixes #26.