### PR TITLE
.pullapprove.yml: List project maintainers separately

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -40,3 +40,6 @@ groups:
   runtime-tools:
     teams:
       - runtime-tools-maintainers
+  selinux:
+    teams:
+      - selinux-maintainers

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,13 +1,36 @@
-approve_by_comment: true
-approve_regex: ^LGTM
-reject_regex: ^Rejected
-reset_on_push: true
-author_approval: ignored
-signed_off_by:
-  required: true
-reviewers:
-  teams:
-  - tdc-maintainers
-  - admins
-  name: default
+version: 2
+
+requirements:
+  signed_off_by:
+    required: true
+
+group_defaults:
   required: 2
+  approve_by_comment:
+    enabled: true
+    approve_regex: ^LGTM
+    reject_regex: ^Rejected
+  reset_on_push:
+    enabled: true
+  author_approval:
+    ignored: true
+
+groups:
+  image-spec:
+    teams:
+      - image-spec-maintainers
+  image-tools:
+    teams:
+      - image-tools-maintainers
+  go-digest:
+    teams:
+      - go-digest-maintainers
+  runc:
+    teams:
+      - runc-maintainers
+  runtime-spec:
+    teams:
+      - runtime-spec-maintainers
+  runtime-tools:
+    teams:
+      - runtime-tools-maintainers

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -18,6 +18,9 @@ group_defaults:
     enabled: true
   author_approval:
     ignored: true
+  conditions:
+    branches:
+      - master
 
 groups:
   image-spec:

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -4,10 +4,6 @@ requirements:
   signed_off_by:
     required: true
 
-always_pending:
-  title_regex: ^WIP
-  explanation: 'Work in progress...'
-
 group_defaults:
   required: 2
   approve_by_comment:
@@ -18,6 +14,9 @@ group_defaults:
     enabled: true
   author_approval:
     ignored: true
+  always_pending:
+    title_regex: ^WIP
+    explanation: 'Work in progress...'
   conditions:
     branches:
       - master

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -4,6 +4,10 @@ requirements:
   signed_off_by:
     required: true
 
+always_pending:
+  title_regex: ^WIP
+  explanation: 'Work in progress...'
+
 group_defaults:
   required: 2
   approve_by_comment:


### PR DESCRIPTION
This repository is managed by the union of all OCI Project maintainers.  To avoid having a few active maintainers from one project driving the template in ways that other projects don't support, require at least two approvals from each project.  This will slow down acceptance a bit, but many maintainers belong to multiple projects (and [their votes will count for each group][1]), so you won't need 12 separate maintainers voting to get a single project-template PR across the line.

A side benefit of this is that we no longer need to maintain the tdc-maintainers team.

Also [update][1] from config format v1 to [v2][2] and pull in some new features (which I can spin off into separate PRs if they turn out to be controversial).

[1]: http://docs.pullapprove.com/migrating-to-v2/
[2]: http://docs.pullapprove.com/