### PR TITLE
GOVERNANCE: Fix "release" -> "motion" typo

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -15,7 +15,7 @@ A maintainer SHOULD propose a motion on the dev@opencontainers.org mailing list 
 Voting on a proposed motion SHOULD happen on the dev@opencontainers.org mailing list (except [security issues](#security-issues)) with maintainers posting LGTM or REJECT.
 Maintainers MAY also explicitly not vote by posting ABSTAIN (which is useful to revert a previous vote).
 Maintainers MAY post multiple times (e.g. as they revise their position based on feeback), but only their final post counts in the tally.
-A proposed motion is adopted if two-thirds of votes cast, a quorum having voted, are in favor of the release.
+A proposed motion is adopted if two-thirds of votes cast, a quorum having voted, are in favor of the motion.
 
 Voting SHOULD remain open for a week to collect feedback from the wider community and allow the maintainers to digest the proposed motion.
 Under exceptional conditions (e.g. non-major security fix releases) proposals which reach quorum with unanimous support MAY be adopted earlier.


### PR DESCRIPTION
I'd missed this in c732cc2e (#15).

I consider this a typo-fix, in which case it only needs two LGTMs (per-OCI-Project?  #29).  If folks feel like it's a governance change it would need a ⅔ vote.