### PR TITLE
.pullapprove.yml: Count rejections against

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -6,6 +6,7 @@ requirements:
 
 group_defaults:
   required: 2
+  reject_value: -1
   approve_by_comment:
     enabled: true
     approve_regex: ^LGTM


### PR DESCRIPTION
Distinguish between “I haven't looked at this” (no need to say anything) and “I have looked at this and don't like it” (say something matching the reject_regex).

Spun off from #29, since it's an independent change and there was [some question about whether we want it][1].  I think we do want it, but either way, there's no need to hold up #29 before we decide on this point.  #29 should be reviewed first, because this commit sits on top of it.

Docs [here][2].

[1]: https://github.com/opencontainers/project-template/pull/29#discussion_r106581367
[2]: http://docs.pullapprove.com/groups/reject_value/