### PR TITLE
GOVERNANCE: List selinux project

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -34,7 +34,7 @@ For projects that are not specifications, a [motion to release](#release-approva
 ## Amendments
 
 The [project governance](#project-governance) rules and procedures MAY be amended or replaced using the procedures themselves.
-The MAINTAINERS of this project governance document is the total set of MAINTAINERS from all Open Containers projects (go-digest, image-spec, image-tools, runC, runtime-spec, and runtime-tools).
+The MAINTAINERS of this project governance document is the total set of MAINTAINERS from all Open Containers projects (go-digest, image-spec, image-tools, runC, runtime-spec, runtime-tools, and selinux).
 
 ## Subject templates
 


### PR DESCRIPTION
Catching up with opencontainers/tob#29 and the [subsequent rename][1].

I'd still rather drop the parenthetical entirely and link to a place that listed OCI Projects, but we don't have a canonical target for that yet (opencontainers/tob#2) and the current closest instance seems to be the GitHub section in [2] (which doesn't have the "OCI Project" words).

Like #24.

@caniszczyk, it looks like [the opencontainers.org page][2] still needs “go-selinux” → “selinux”.

[1]: https://github.com/opencontainers/selinux/issues/6#issuecomment-285428099
[2]: https://www.opencontainers.org/community