### PR TITLE
GOVERNANCE: Allow dev@ or PR votes for non-spec projects

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -6,13 +6,21 @@ The [OCI charter][charter] §5.b.viii tasks an OCI Project's maintainers (listed
 
 This section describes generic rules and procedures for fulfilling that mandate.
 
+## Motion locations
+
+Motions involving security issues SHOULD be proposed and voted on as described [here](CONTRIBUTING.md#security-issues).
+For motions which do not involve security issues:
+
+* Projects which include specifications SHOULD propose motions and collect votes on the [`dev@opencontainers.org`][dev-list] mailing list.
+* Projects which do not include specifications SHOULD propose motions and collect votes on either the [`dev@opencontainers.org`][dev-list] mailing list or on a pull-request in the project repository.
+
 ## Proposing a motion
 
-A maintainer SHOULD propose a motion on the dev@opencontainers.org mailing list (except [security issues](#security-issues)) with another maintainer as a co-sponsor.
+A maintainer SHOULD propose a motion [in the proper location](#motion-locations) with another maintainer as a co-sponsor.
 
 ## Voting
 
-Voting on a proposed motion SHOULD happen on the dev@opencontainers.org mailing list (except [security issues](#security-issues)) with maintainers posting LGTM or REJECT.
+Voting on a proposed motion SHOULD happen [in the proper location](#motion-locations) with maintainers posting LGTM or REJECT.
 Maintainers MAY also explicitly not vote by posting ABSTAIN (which is useful to revert a previous vote).
 Maintainers MAY post multiple times (e.g. as they revise their position based on feeback), but only their final post counts in the tally.
 A proposed motion is adopted if two-thirds of votes cast, a quorum having voted, are in favor of the release.
@@ -61,3 +69,4 @@ For example:
 > [runtime-spec adopted]: Tag 0647920 as 1.0.0-rc (+6 -0 #3)
 
 [charter]: https://www.opencontainers.org/about/governance
+[dev-list]: https://groups.google.com/a/opencontainers.org/forum/#!forum/dev


### PR DESCRIPTION
Email-based voting seems to be a blocker for @crosbymichael, who [prefers PR-based voting for non-spec projects][1].  And the image-tools maintainers had a PR-only vote to add @cyphar as a maintainer (opencontainers/image-tools#118).

Specifications are still recommended to only use `dev@` (for increased visibility among folks with only peripheral involvement, e.g. spec consumers).  But non-spec projects can backtrack more easily from decisions which have negative impacts, so we don't have to push them towards `dev@` as firmly.

Adopting this more-relaxed approach should help reduce barriers to non-spec projects adopting the vanilla governance procedures, which may move us towards more consistency between OCI projects (#4).

[1]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/%23opencontainers.2017-03-20.log.html#t2017-03-20T19:54:38