### PR TITLE
GOVERNANCE: Fix "feeback" -> "feedback" typo

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -14,7 +14,7 @@ A maintainer SHOULD propose a motion on the dev@opencontainers.org mailing list 
 
 Voting on a proposed motion SHOULD happen on the dev@opencontainers.org mailing list (except [security issues](#security-issues)) with maintainers posting LGTM or REJECT.
 Maintainers MAY also explicitly not vote by posting ABSTAIN (which is useful to revert a previous vote).
-Maintainers MAY post multiple times (e.g. as they revise their position based on feeback), but only their final post counts in the tally.
+Maintainers MAY post multiple times (e.g. as they revise their position based on feedback), but only their final post counts in the tally.
 A proposed motion is adopted if two-thirds of votes cast, a quorum having voted, are in favor of the release.
 
 Voting SHOULD remain open for a week to collect feedback from the wider community and allow the maintainers to digest the proposed motion.


### PR DESCRIPTION
Cherry-picked from opencontainers/runtime-spec#752 and updated the commit message to be more specific.

CC @q384566678, since I've left your Signed-off-by on the commit (there was no change in the diff).