### PR TITLE
small fix based on pullapprove document

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -4,19 +4,20 @@ requirements:
   signed_off_by:
     required: true
 
+always_pending:
+  title_regex: '^WIP'
+  explanation: 'Work in progress...'
+
 group_defaults:
   required: 2
   approve_by_comment:
     enabled: true
-    approve_regex: ^LGTM
-    reject_regex: ^Rejected
+    approve_regex: '^LGTM'
+    reject_regex: '^Rejected'
   reset_on_push:
     enabled: true
   author_approval:
     ignored: true
-  always_pending:
-    title_regex: ^WIP
-    explanation: 'Work in progress...'
   conditions:
     branches:
       - master


### PR DESCRIPTION
Other projects may refer to template's pullapprove config file.
I think we'd better based on pullapprove's document.
This will reduce doubts of pullapprove grammar.

Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>