### PR TITLE
.pullapprove.yml: Fix 'selinux-maintainers' -> 'go-selinux-maintainers'

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -42,4 +42,4 @@ groups:
       - runtime-tools-maintainers
   selinux:
     teams:
-      - selinux-maintainers
+      - go-selinux-maintainers


### PR DESCRIPTION
GitHub doesn't expose these group names to users outside of the organization, but [`go-selinux-maintainers` is what the selinux repo uses][1] and [PullApprove seems happy with it][2].  I expect the group wasn't renamed when the repository was.

[1]: https://github.com/opencontainers/selinux/blob/v1.0.0-rc1/.pullapprove.yml#L9
[2]: https://pullapprove.com/opencontainers/go-selinux/pull-request/15/reviews/