### PR TITLE
MAINTAINERS: Explain the format and reference other projects

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,8 @@
+This meta-project is maintained by the union of MAINTAINERS for all OCI Projects [1].
+
+Other OCI Projects should list one maintainer per line, with a name, email address, and GitHub username:
+
+Random J Developer <random@developer.example.org> (@RandomJDeveloperExample)
+A. U. Thor <author@example.org> (@AUThorExample)
+
+[1]: https://github.com/opencontainers/


### PR DESCRIPTION
Spun off from #20.

Currently the OCI seems to have one repository per Project.  A few repositories are not official projects; for example, [artwork][2] may never be a Project.  But I expect that going forward, any opencontainers/ repos that have a `MAINTAINERS` file will be official Projects, so the union rule here should be both correct and easy to maintain.

The file is not Markdown, so I've gone with my usual reference-style link instead of a Markdown reference-style link.

[2]: https://github.com/opencontainers/artwork