### PR TITLE
CONTRIBUTING: Code of conduct, meetings, mailing list, and IRC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,6 @@
-## Contribution Guidelines
+# Contribution Guidelines
+
+## Git
 
 ### Security issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,30 @@
 # Contribution Guidelines
 
+Development happens on GitHub.
+Issues are used for bugs and actionable items and longer discussions can happen on the [mailing list](#mailing-list).
+
+The content of this repository is licensed under the [Apache License, Version 2.0](LICENSE).
+
+## Code of Conduct
+
+Participation in the Open Container community is governed by [Open Container Code of Conduct][code-of-conduct].
+
+## Meetings
+
+The contributors and maintainers of all OCI projects have monthly meetings at 2:00 PM (USA Pacific) on the first Wednesday of every month.
+There is an [iCalendar][rfc5545] format for the meetings [here][meeting.ics].
+Everyone is welcome to participate via [UberConference web][UberConference] or audio-only: +1 415 968 0849 (no PIN needed).
+An initial agenda will be posted to the [mailing list](#mailing-list) in the week before each meeting, and everyone is welcome to propose additional topics or suggest other agenda alterations there.
+Minutes from past meetings are archived [here][minutes].
+
+## Mailing list
+
+You can subscribe and browse the mailing list on [Google Groups][mailing-list].
+
+## IRC
+
+OCI discussion happens on #opencontainers on [Freenode][] ([logs][irc-logs]).
+
 ## Git
 
 ### Security issues
@@ -28,7 +53,7 @@ incorporating a new feature.
 
 Fork the repo and make changes on your fork in a feature branch.
 For larger bugs and enhancements, consider filing a leader issue or mailing-list thread for discussion that is independent of the implementation.
-Small changes or changes that have been discussed on the project mailing list may be submitted without a leader issue.
+Small changes or changes that have been discussed on the [project mailing list](#mailing-list) may be submitted without a leader issue.
 
 If the project has a test suite, submit unit tests for your changes. Take a
 look at existing tests for inspiration. Run the full test suite on your branch
@@ -70,8 +95,7 @@ or `Fixes #XXX`, which will automatically close the issue when merged.
 The sign-off is a simple line at the end of the explanation for the
 patch, which certifies that you wrote it or otherwise have the right to
 pass it on as an open-source patch.  The rules are pretty simple: if you
-can certify the below (from
-[developercertificate.org](http://developercertificate.org/)):
+can certify the below (from [developercertificate.org][]):
 
 ```
 Developer Certificate of Origin
@@ -120,3 +144,12 @@ then you just add a line to every git commit message:
 using your real name (sorry, no pseudonyms or anonymous contributions.)
 
 You can add the sign off when creating the git commit via `git commit -s`.
+
+[code-of-conduct]: https://github.com/opencontainers/tob/blob/d2f9d68c1332870e40693fe077d311e0742bc73d/code-of-conduct.md
+[developercertificate.org]: http://developercertificate.org/
+[Freenode]: https://freenode.net/
+[irc-logs]: http://ircbot.wl.linuxfoundation.org/eavesdrop/%23opencontainers/
+[mailing-list]: https://groups.google.com/a/opencontainers.org/forum/#!forum/dev
+[meeting.ics]: https://github.com/opencontainers/runtime-spec/blob/master/meeting.ics
+[minutes]: http://ircbot.wl.linuxfoundation.org/meetings/opencontainers/
+[UberConference]: https://www.uberconference.com/opencontainers


### PR DESCRIPTION
So far dev@ volume has been low enough that [we haven't needed per-project lists][1], so we can add it in this central location.  In the event that we do split lists later, the reference-style link makes it easy for projects to update the target without touching the line with the link text.  The meetings and IRC channel are in the same boat (not enought traffic to be worth splitting).  The content I'm adding here is adapted from [here][2] and [here][3].  As long as the meeting is shared, linking the runtime-spec maintained meeting.ics seemed easier than keeping a parallel copy here.

The CoC titles itself "OpenContainers Code of Conduct", but [opencontainers.org][4] has:

> Connecting with the Open Container Initiative community

And I feel like I've been seeing the singular, spaced form more frequently.

Spun off from #20.
While we're adding reference-style links, convert the DCO link as well to make the text easier to read.

[1]: https://groups.google.com/a/opencontainers.org/d/msg/dev/Ctw-fcO1IuA/7vrr4YiyDgAJ
[2]: https://github.com/opencontainers/runtime-spec/blob/7a36e7ed86ee3b4c6dbcdbd02052ec1ef6787c3c/README.md#contributing
[3]: https://github.com/opencontainers/runtime-spec/blob/1077f05ae7b05ce79159e66c25f8ff80f58ffedb/README.md#meetings
[4]: https://www.opencontainers.org/community