### PR TITLE
CONTRIBUTING: Remove gofmt advice

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,6 @@ your documentation changes for clarity, concision, and correctness, as
 well as a clean documentation build. See ``docs/README.md`` for more
 information on building the docs and how docs get released.
 
-Write clean code. Universally formatted code promotes ease of writing, reading,
-and maintenance. Always run `gofmt -s -w file.go` on each changed file before
-committing your changes. Most editors have plugins that do this automatically.
-
 Pull requests descriptions should be as clear as possible and include a
 reference to all the issues that they address.
 


### PR DESCRIPTION
Spun off from #20.

Not all OCI Projects are primarily Go, and filling in off-topic formatting advice doesn't seem useful.  One approach to this would be to require projects to support `make fmt` to handle any auto-formatting.  But an easier approach is to keep the document [generic in this repository][1], and allow downstream projects to add their own project-specific content as they see fit.  I don't expect a lot of churn in this document, so there shouldn't be many conflicts between those downstream changes and further project-template development.

[1]: https://github.com/opencontainers/project-template/issues/4#issuecomment-221081999