### PR TITLE
CONTRIBUTING: Remove docs/README.md reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,7 @@ before submitting a pull request.
 
 Update the documentation when creating or modifying features. Test
 your documentation changes for clarity, concision, and correctness, as
-well as a clean documentation build. See ``docs/README.md`` for more
-information on building the docs and how docs get released.
+well as a clean documentation build.
 
 Write clean code. Universally formatted code promotes ease of writing, reading,
 and maintenance. Always run `gofmt -s -w file.go` on each changed file before


### PR DESCRIPTION
Spun off from #20.

Current [runtime-tools docs for the man pages are under man/][0].  No docs for building them yet beyond the Makefile rule, and that may be all we need ;).  Because there is no downstream consensus on doc locations, remove the reference.  Downstream repositories can add it (or similar content) back in [as they see fit][1].  I don't expect a lot of churn in this document, so there shouldn't be many conflicts between those downstream changes and further project-template development.

[0]: https://github.com/opencontainers/runtime-tools/tree/v0.5.0/man
[1]: https://github.com/opencontainers/project-template/issues/4#issuecomment-221081999