### PR TITLE
MAINTAINERS_GUIDE: Remove enumeratations for responsibilities

### DIFF
--- a/MAINTAINERS_GUIDE.md
+++ b/MAINTAINERS_GUIDE.md
@@ -22,12 +22,11 @@ speak up!
 
 It is every maintainer's responsibility to:
 
-* 1) Expose a clear roadmap for improving their component.
-* 2) Deliver prompt feedback and decisions on pull requests.
-* 3) Be available to anyone with questions, bug reports, criticism etc.
-  on their component. This includes IRC and GitHub issues and pull requests.
-* 4) Make sure their component respects the philosophy, design and
-  roadmap of the project.
+* Expose a clear roadmap for improving their component.
+* Deliver prompt feedback and decisions on pull requests.
+* Be available to anyone with questions, bug reports, criticism etc. on their component.
+  This includes IRC and GitHub issues and pull requests.
+* Make sure their component respects the philosophy, design and roadmap of the project.
 
 ## How are decisions made?
 


### PR DESCRIPTION
Spun off from #20.

If we wanted to enumerate these we should use Markdown's enumerated list.  But these aren't ordered, so remove the old enumerations.

Also adjust one line per sentence, since that's the standard in other OCI projects (like [the runtime spec][1]).

[1]: https://github.com/opencontainers/runtime-spec/blob/v1.0.1/style.md#one-sentence-per-line