### PR TITLE
.pullapprove.yml: Add distribution-spec-maintainers

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -23,6 +23,9 @@ group_defaults:
       - master
 
 groups:
+  distribution-spec:
+    teams:
+      - distribution-spec-maintainers
   image-spec:
     teams:
       - image-spec-maintainers

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -34,7 +34,7 @@ For projects that are not specifications, a [motion to release](#release-approva
 ## Amendments
 
 The [project governance](#project-governance) rules and procedures MAY be amended or replaced using the procedures themselves.
-The MAINTAINERS of this project governance document is the total set of MAINTAINERS from all Open Containers projects (go-digest, image-spec, image-tools, runC, runtime-spec, runtime-tools, and selinux).
+The MAINTAINERS of this project governance document is the total set of MAINTAINERS from all Open Containers projects (distribution-spec, go-digest, image-spec, image-tools, runC, runtime-spec, runtime-tools, and selinux).
 
 ## Subject templates
 


### PR DESCRIPTION
Catching up with opencontainers/tob#35.

We'll want this if we're trying to continue with the “two maintainers from every OCI Project have LGTMed” approach initially adopted in f412693f (#29).  See #41 for some other maintenance ideas; but as long as that's open I think we need to continue with the current pattern.