### PR TITLE
CONTRIBUTING: Add "usually" wiggle to the meeting text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Participation in the Open Container community is governed by [Open Container Cod
 
 ## Meetings
 
-The contributors and maintainers of all OCI projects have monthly meetings at 2:00 PM (USA Pacific) on the first Wednesday of every month.
+The contributors and maintainers of all OCI projects have monthly meetings, which are usually at 2:00 PM (USA Pacific) on the first Wednesday of every month.
 There is an [iCalendar][rfc5545] format for the meetings [here][meeting.ics].
 Everyone is welcome to participate via [UberConference web][UberConference] or audio-only: +1 415 968 0849 (no PIN needed).
 An initial agenda will be posted to the [mailing list](#mailing-list) in the week before each meeting, and everyone is welcome to propose additional topics or suggest other agenda alterations there.


### PR DESCRIPTION
This allows us to make occasional exceptions, e.g. [around the holidays][1], without needing to adjust the text in all consuming projects.  Instead, we can just ping the mailing list and bump the central iCalendar in runtime-spec (or wherever we end up keeping the central iCalendar).

The text is from the recently-landed opencontainers/runtime-spec#943 as part of synchronizing this repository with current downstream improvements (#4).

[1]: https://groups.google.com/a/opencontainers.org/d/msg/dev/FzclHQsMH_c/QKJMybRkBAAJ